### PR TITLE
Feat/add upload stream

### DIFF
--- a/examples/next-starter/app/api/files/route.ts
+++ b/examples/next-starter/app/api/files/route.ts
@@ -1,21 +1,18 @@
 import { NextResponse, NextRequest } from "next/server";
 import { pinata } from "@/utils/config";
 
-export const config = {
-  api: {
-    bodyParser: false,
-  },
-};
-
 export async function POST(request: NextRequest) {
-  try {
-    const data = await request.formData();
-    const file: File | null = data.get("file") as unknown as File;
-    const uploadData = await pinata.upload.file(file);
-    const url = await pinata.gateways.convert(uploadData.IpfsHash);
-    return NextResponse.json(url, { status: 200 });
-  } catch (e) {
-    console.log(e);
-    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
-  }
+	try {
+		const data = await request.formData();
+		const file: File | null = data.get("file") as unknown as File;
+		const uploadData = await pinata.upload.file(file);
+		const url = await pinata.gateways.convert(uploadData.IpfsHash);
+		return NextResponse.json(url, { status: 200 });
+	} catch (e) {
+		console.log(e);
+		return NextResponse.json(
+			{ error: "Internal Server Error" },
+			{ status: 500 },
+		);
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.4.1",
 			"license": "MIT",
 			"dependencies": {
+				"axios": "^1.7.7",
+				"form-data": "^4.0.0",
 				"is-ipfs": "^8.0.4",
 				"node-fetch": "^3.3.1"
 			},
@@ -1852,9 +1854,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
-			"integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.5.tgz",
+			"integrity": "sha512-SU5cvamg0Eyu/F+kLeMXS7GoahL+OoizlclVFX3l5Ql6yNlywJJ0OuqTzUx0v+aHhPHEB/56CT06GQrRrGNYww==",
 			"cpu": [
 				"arm"
 			],
@@ -1865,9 +1867,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
-			"integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.5.tgz",
+			"integrity": "sha512-S4pit5BP6E5R5C8S6tgU/drvgjtYW76FBuG6+ibG3tMvlD1h9LHVF9KmlmaUBQ8Obou7hEyS+0w+IR/VtxwNMQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1878,9 +1880,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
-			"integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.5.tgz",
+			"integrity": "sha512-250ZGg4ipTL0TGvLlfACkIxS9+KLtIbn7BCZjsZj88zSg2Lvu3Xdw6dhAhfe/FjjXPVNCtcSp+WZjVsD3a/Zlw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1891,9 +1893,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
-			"integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.5.tgz",
+			"integrity": "sha512-D8brJEFg5D+QxFcW6jYANu+Rr9SlKtTenmsX5hOSzNYVrK5oLAEMTUgKWYJP+wdKyCdeSwnapLsn+OVRFycuQg==",
 			"cpu": [
 				"x64"
 			],
@@ -1904,9 +1906,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
-			"integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.5.tgz",
+			"integrity": "sha512-PNqXYmdNFyWNg0ma5LdY8wP+eQfdvyaBAojAXgO7/gs0Q/6TQJVXAXe8gwW9URjbS0YAammur0fynYGiWsKlXw==",
 			"cpu": [
 				"arm"
 			],
@@ -1917,9 +1919,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
-			"integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.5.tgz",
+			"integrity": "sha512-kSSCZOKz3HqlrEuwKd9TYv7vxPYD77vHSUvM2y0YaTGnFc8AdI5TTQRrM1yIp3tXCKrSL9A7JLoILjtad5t8pQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1930,9 +1932,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
-			"integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.5.tgz",
+			"integrity": "sha512-oTXQeJHRbOnwRnRffb6bmqmUugz0glXaPyspp4gbQOPVApdpRrY/j7KP3lr7M8kTfQTyrBUzFjj5EuHAhqH4/w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1943,9 +1945,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
-			"integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.5.tgz",
+			"integrity": "sha512-qnOTIIs6tIGFKCHdhYitgC2XQ2X25InIbZFor5wh+mALH84qnFHvc+vmWUpyX97B0hNvwNUL4B+MB8vJvH65Fw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1956,9 +1958,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
-			"integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.5.tgz",
+			"integrity": "sha512-TMYu+DUdNlgBXING13rHSfUc3Ky5nLPbWs4bFnT+R6Vu3OvXkTkixvvBKk8uO4MT5Ab6lC3U7x8S8El2q5o56w==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1969,9 +1971,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
-			"integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.5.tgz",
+			"integrity": "sha512-PTQq1Kz22ZRvuhr3uURH+U/Q/a0pbxJoICGSprNLAoBEkyD3Sh9qP5I0Asn0y0wejXQBbsVMRZRxlbGFD9OK4A==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1982,9 +1984,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
-			"integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.5.tgz",
+			"integrity": "sha512-bR5nCojtpuMss6TDEmf/jnBnzlo+6n1UhgwqUvRoe4VIotC7FG1IKkyJbwsT7JDsF2jxR+NTnuOwiGv0hLyDoQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -1995,9 +1997,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
-			"integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.5.tgz",
+			"integrity": "sha512-N0jPPhHjGShcB9/XXZQWuWBKZQnC1F36Ce3sDqWpujsGjDz/CQtOL9LgTrJ+rJC8MJeesMWrMWVLKKNR/tMOCA==",
 			"cpu": [
 				"x64"
 			],
@@ -2008,9 +2010,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
-			"integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.5.tgz",
+			"integrity": "sha512-uBa2e28ohzNNwjr6Uxm4XyaA1M/8aTgfF2T7UIlElLaeXkgpmIJ2EitVNQxjO9xLLLy60YqAgKn/AqSpCUkE9g==",
 			"cpu": [
 				"x64"
 			],
@@ -2021,9 +2023,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
-			"integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.5.tgz",
+			"integrity": "sha512-RXT8S1HP8AFN/Kr3tg4fuYrNxZ/pZf1HemC5Tsddc6HzgGnJm0+Lh5rAHJkDuW3StI0ynNXukidROMXYl6ew8w==",
 			"cpu": [
 				"arm64"
 			],
@@ -2034,9 +2036,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
-			"integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.5.tgz",
+			"integrity": "sha512-ElTYOh50InL8kzyUD6XsnPit7jYCKrphmddKAe1/Ytt74apOxDq5YEcbsiKs0fR3vff3jEneMM+3I7jbqaMyBg==",
 			"cpu": [
 				"ia32"
 			],
@@ -2047,9 +2049,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
-			"integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.5.tgz",
+			"integrity": "sha512-+lvL/4mQxSV8MukpkKyyvfwhH266COcWlXE/1qxwN08ajovta3459zrjLghYMgDerlzNwLAcFpvU+WWE5y6nAQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2165,9 +2167,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true
 		},
 		"node_modules/@types/graceful-fs": {
@@ -2361,6 +2363,21 @@
 			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"node_modules/axios": {
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+			"integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+			"dependencies": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
+			}
 		},
 		"node_modules/babel-jest": {
 			"version": "29.7.0",
@@ -2906,6 +2923,17 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/commander": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3019,6 +3047,14 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/detect-newline": {
@@ -3372,6 +3408,25 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/foreground-child": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -3398,6 +3453,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/formdata-polyfill": {
@@ -4874,9 +4942,9 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -4884,6 +4952,25 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -5356,6 +5443,11 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5492,12 +5584,12 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
-			"integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.5.tgz",
+			"integrity": "sha512-WoinX7GeQOFMGznEcWA1WrTQCd/tpEbMkc3nuMs9BT0CPjMdSjPMTVClwWd4pgSQwJdP65SK9mTCNvItlr5o7w==",
 			"dev": true,
 			"dependencies": {
-				"@types/estree": "1.0.5"
+				"@types/estree": "1.0.6"
 			},
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -5507,22 +5599,22 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.18.0",
-				"@rollup/rollup-android-arm64": "4.18.0",
-				"@rollup/rollup-darwin-arm64": "4.18.0",
-				"@rollup/rollup-darwin-x64": "4.18.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
-				"@rollup/rollup-linux-arm-musleabihf": "4.18.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.18.0",
-				"@rollup/rollup-linux-arm64-musl": "4.18.0",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.18.0",
-				"@rollup/rollup-linux-s390x-gnu": "4.18.0",
-				"@rollup/rollup-linux-x64-gnu": "4.18.0",
-				"@rollup/rollup-linux-x64-musl": "4.18.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.18.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.18.0",
-				"@rollup/rollup-win32-x64-msvc": "4.18.0",
+				"@rollup/rollup-android-arm-eabi": "4.22.5",
+				"@rollup/rollup-android-arm64": "4.22.5",
+				"@rollup/rollup-darwin-arm64": "4.22.5",
+				"@rollup/rollup-darwin-x64": "4.22.5",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.22.5",
+				"@rollup/rollup-linux-arm-musleabihf": "4.22.5",
+				"@rollup/rollup-linux-arm64-gnu": "4.22.5",
+				"@rollup/rollup-linux-arm64-musl": "4.22.5",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.22.5",
+				"@rollup/rollup-linux-riscv64-gnu": "4.22.5",
+				"@rollup/rollup-linux-s390x-gnu": "4.22.5",
+				"@rollup/rollup-linux-x64-gnu": "4.22.5",
+				"@rollup/rollup-linux-x64-musl": "4.22.5",
+				"@rollup/rollup-win32-arm64-msvc": "4.22.5",
+				"@rollup/rollup-win32-ia32-msvc": "4.22.5",
+				"@rollup/rollup-win32-x64-msvc": "4.22.5",
 				"fsevents": "~2.3.2"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -1,13 +1,11 @@
 {
 	"name": "pinata-web3",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"description": "The new Pinata IPFS SDK",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"exports": {
 		".": {
 			"require": "./dist/index.js",
@@ -24,11 +22,7 @@
 		"type": "git",
 		"url": "https://github.com/PinataCloud/pinata-web3.git"
 	},
-	"keywords": [
-		"ipfs",
-		"sdk",
-		"typescript"
-	],
+	"keywords": ["ipfs", "sdk", "typescript"],
 	"author": "Steve Simkins",
 	"license": "MIT",
 	"bugs": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"exports": {
 		".": {
 			"require": "./dist/index.js",
@@ -22,7 +24,11 @@
 		"type": "git",
 		"url": "https://github.com/PinataCloud/pinata-web3.git"
 	},
-	"keywords": ["ipfs", "sdk", "typescript"],
+	"keywords": [
+		"ipfs",
+		"sdk",
+		"typescript"
+	],
 	"author": "Steve Simkins",
 	"license": "MIT",
 	"bugs": {
@@ -33,13 +39,15 @@
 		"@biomejs/biome": "1.8.3",
 		"@types/jest": "^29.5.12",
 		"@types/node": "^20.11.17",
+		"jest": "^29.7.0",
+		"ts-jest": "^29.2.2",
 		"ts-node": "^10.9.2",
 		"tsup": "^8.0.1",
-		"typescript": "^5.3.3",
-		"jest": "^29.7.0",
-		"ts-jest": "^29.2.2"
+		"typescript": "^5.3.3"
 	},
 	"dependencies": {
+		"axios": "^1.7.7",
+		"form-data": "^4.0.0",
 		"is-ipfs": "^8.0.4",
 		"node-fetch": "^3.3.1"
 	}

--- a/src/core/pinataSDK.ts
+++ b/src/core/pinataSDK.ts
@@ -45,6 +45,7 @@ import { uploadBase64 } from "./pinning/base64";
 import { uploadUrl } from "./pinning/url";
 import { uploadJson } from "./pinning/json";
 import { uploadCid } from "./pinning/cid";
+import { uploadStream } from "./pinning/stream";
 import { unpinFile } from "./pinning/unpin";
 import { listFiles } from "./data/listFiles";
 import { updateMetadata } from "./data/updateMetadata";
@@ -260,6 +261,13 @@ class Upload {
 
 	json(data: object, options?: UploadOptions): UploadBuilder<PinResponse> {
 		return new UploadBuilder(this.config, uploadJson, data, options);
+	}
+
+	stream(
+		stream: NodeJS.ReadableStream,
+		options?: UploadOptions,
+	): UploadBuilder<PinResponse> {
+		return new UploadBuilder(this.config, uploadStream, stream, options);
 	}
 
 	cid(

--- a/src/core/pinning/stream.ts
+++ b/src/core/pinning/stream.ts
@@ -1,0 +1,141 @@
+/**
+ * Uploads a file to IPFS via Pinata.
+ *
+ * This function allows you to upload a single file to IPFS and pin it to Pinata.
+ * It's useful for adding individual files to your Pinata account and IPFS network.
+ *
+ * @async
+ * @function uploadFile
+ * @param {PinataConfig | undefined} config - The Pinata configuration object containing the JWT.
+ * @param {File} file - The file object to be uploaded.
+ * @param {UploadOptions} [options] - Optional parameters for the upload.
+ * @param {PinataMetadata} [options.metadata] - Metadata for the uploaded file.
+ * @param {string} [options.metadata.name] - Custom name for the file (defaults to the original filename if not provided).
+ * @param {Record<string, string | number>} [options.metadata.keyValues] - Custom key-value pairs for the file metadata.
+ * @param {string} [options.keys] - Custom JWT to use for this specific upload.
+ * @param {string} [options.groupId] - ID of the group to add the uploaded file to.
+ * @param {0 | 1} [options.cidVersion] - Version of CID to use (0 or 1).
+ * @returns {Promise<PinResponse>} A promise that resolves to an object containing the IPFS hash and other upload details.
+ * @throws {ValidationError} If the Pinata configuration or JWT is missing.
+ * @throws {AuthenticationError} If the authentication fails (e.g., invalid JWT).
+ * @throws {NetworkError} If there's a network-related error during the API request.
+ * @throws {PinataError} For any other errors that occur during the upload process.
+ *
+ * @example
+ * import { PinataSDK } from "pinata";
+ *
+ * const pinata = new PinataSDK({
+ *   pinataJwt: process.env.PINATA_JWT!,
+ *   pinataGateway: "example-gateway.mypinata.cloud",
+ * });
+ *
+ * const file = new File(["hello world!"], "hello.txt", { type: "text/plain" })
+ * const upload = await pinata.upload.file(file)
+ */
+
+import type { PinataConfig, PinResponse, UploadOptions } from "../types";
+import {
+	PinataError,
+	NetworkError,
+	AuthenticationError,
+	ValidationError,
+} from "../../utils/custom-errors";
+import type * as AxiosStatic from "axios";
+import FormData from "form-data";
+
+let axiosModule: typeof AxiosStatic;
+
+async function getAxios() {
+	if (!axiosModule) {
+		axiosModule = await import("axios");
+	}
+	return axiosModule.default;
+}
+export const uploadStream = async (
+	config: PinataConfig | undefined,
+	stream: NodeJS.ReadableStream,
+	options?: UploadOptions,
+) => {
+	if (!config) {
+		throw new ValidationError("Pinata configuration is missing");
+	}
+
+	const axios = await getAxios();
+
+	const jwt: string | undefined = options?.keys || config.pinataJwt;
+
+	const data = new FormData();
+
+	data.append("file", stream, {
+		filepath: "filepath",
+		filename: "filename",
+	});
+
+	data.append(
+		"pinataOptions",
+		JSON.stringify({
+			cidVersion: options?.cidVersion,
+			groupId: options?.groupId,
+		}),
+	);
+
+	data.append(
+		"pinataMetadata",
+		JSON.stringify({
+			name: options?.metadata?.name || "Stream from SDK",
+			keyvalues: options?.metadata?.keyValues,
+		}),
+	);
+
+	let headers: Record<string, string>;
+
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${jwt}`,
+			Source: "sdk/stream",
+		};
+	}
+
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
+	try {
+		const request = await axios(`${endpoint}/pinning/pinFileToIPFS`, {
+			maxBodyLength: undefined,
+			method: "POST",
+			headers: headers,
+			data: data,
+		});
+
+		if (request.status !== 200) {
+			const errorData = await request.data;
+			if (request.status === 401 || request.status === 403) {
+				throw new AuthenticationError(
+					`Authentication failed: ${errorData}`,
+					request.status,
+					errorData,
+				);
+			}
+			throw new NetworkError(
+				`HTTP error: ${errorData}`,
+				request.status,
+				errorData,
+			);
+		}
+		const res: PinResponse = await request.data;
+		return res;
+	} catch (error) {
+		if (error instanceof PinataError) {
+			throw error;
+		}
+		if (error instanceof Error) {
+			throw new PinataError(`Error uploading file: ${error.message}`);
+		}
+		throw new PinataError("An unknown error occurred while uploading the file");
+	}
+};


### PR DESCRIPTION
This PR adds a new upload method called `stream`, which allows users to us `fs.createReadStream` as the parameter and avoid passing a whole file into memory

```typescript
const stream = fs.createReadStream("path/to/file")
const upload = await pinata.upload.stream(stream)
```