### PR TITLE
fix: Fixed header interpretation for content types

### DIFF
--- a/src/core/gateway/getCid.ts
+++ b/src/core/gateway/getCid.ts
@@ -101,7 +101,8 @@ export const getCid = async (
 			);
 		}
 
-		const contentType: string | null = request.headers.get("content-type");
+		const contentType: string | null =
+			request.headers.get("content-type")?.split(";")[0] || null;
 
 		if (contentType?.includes("application/json")) {
 			data = await request.json();


### PR DESCRIPTION
Adds a split to the content type header in `gateways.get` to prevent charsets from interfering with types