### PR TITLE
fix: Update file paths in fileArray

### DIFF
--- a/src/core/pinning/fileArray.ts
+++ b/src/core/pinning/fileArray.ts
@@ -59,7 +59,8 @@ export const uploadFileArray = async (
 	const data = new FormData();
 
 	for (const file of Array.from(files)) {
-		data.append("file", file, `${folder}/${file.name}`);
+		const path = file.webkitRelativePath || `${folder}/${file.name}`;
+		data.append("file", file, path);
 	}
 
 	data.append(


### PR DESCRIPTION
This PR fixes an issue with the `fileArray` method which previously did not account for relative file paths, creating folders without their original structure. By first checking the `File` object for the `webkitRelativePath` property we can resolve this for folder that include it. 